### PR TITLE
refactor: account creation and konnector run :art:

### DIFF
--- a/src/components/AccountConnection.jsx
+++ b/src/components/AccountConnection.jsx
@@ -19,6 +19,7 @@ class AccountConnection extends Component {
       })
 
       this.props.submit()
+        .catch(error => this.setState({submitting: false}))
     }
   }
 

--- a/src/components/AccountConnection.jsx
+++ b/src/components/AccountConnection.jsx
@@ -19,7 +19,7 @@ class AccountConnection extends Component {
       })
 
       this.props.submit()
-        .catch(error => this.setState({submitting: false}))
+        .catch(error => this.setState({submitting: false, error: error.message}))
     }
   }
 

--- a/src/containers/ConnectorManagement.jsx
+++ b/src/containers/ConnectorManagement.jsx
@@ -161,34 +161,35 @@ export default class ConnectorManagement extends Component {
     })
   }
 
-  async connectAccount (values) {
+  async connectAccount ({login, password, folderPath}) {
     const { t } = this.context
 
-    this.setState({ submitting: true })
-    // TODO: Replace this automatic folder computation by intent to pick file.
-    this.store.getKonnectorFolder(this.state.connector, values.folder)
-      .then(folder => {
-        if (this.state.connector.connectUrl) {
-          return this.connectAccountOAuth(values)
-        }
+    const account = {
+      auth: {
+        login: login,
+        password: password
+      }
+    }
 
-        return this.store.connectAccount(this.state.connector, values, folder)
-          .then(fetchedConnector => {
-            this.setState({ submitting: false })
-            if (fetchedConnector.importErrorMessage) {
-              this.setState({ error: fetchedConnector.importErrorMessage })
-            } else {
-              this.gotoParent()
-              if (values.folderPath) {
-                Notifier.info(t('account config success'), t('account config details') + values.folderPath)
-              } else {
-                Notifier.info(t('account config success'))
-              }
-            }
-          })
+    this.setState({ submitting: true })
+
+    this.store.connectAccount(this.state.connector, account, folderPath)
+      .then(connection => {
+        this.setState({ submitting: false })
+        if (connection.error) {
+          this.setState({ error: connection.error.message })
+        } else {
+          this.gotoParent()
+          if (folderPath) {
+            Notifier.info(t('account config success'), t('account config details') + folderPath)
+          } else {
+            Notifier.info(t('account config success'))
+          }
+        }
       })
       .catch(error => { // eslint-disable-line
         this.setState({ submitting: false })
+        console.error(error)
         Notifier.error(t('account config error'))
       })
   }

--- a/src/containers/ConnectorManagement.jsx
+++ b/src/containers/ConnectorManagement.jsx
@@ -97,7 +97,7 @@ export default class ConnectorManagement extends Component {
 
   render () {
     const { slug, color, name, customView, accounts, lastImport } = this.state.connector
-    const { isConnected, selectedAccount, isWorking } = this.state
+    const { connector, isConnected, selectedAccount, isWorking } = this.state
     const { t } = this.context
 
     if (isWorking) {
@@ -128,7 +128,7 @@ export default class ConnectorManagement extends Component {
               {...this.context} />
             : <AccountConnection
               connectUrl={prepareConnectURL(this.state.connector)}
-              onSubmit={values => this.connectAccount({values, folder: t('konnector default base folder')})}
+              onSubmit={values => this.connectAccount(Object.assign(values, {folderPath: t('konnector default base folder', connector)}))}
               {...this.state}
               {...this.context} />
           }

--- a/src/containers/ConnectorManagement.jsx
+++ b/src/containers/ConnectorManagement.jsx
@@ -71,19 +71,16 @@ export default class ConnectorManagement extends Component {
 
     this.store.fetchKonnectorInfos(props.params.connectorSlug)
       .then(konnector => {
-        this.store.fetchAccounts(props.params.connectorSlug, null)
-        .then(accounts => {
-          konnector.accounts = accounts
-          this.setState({
-            connector: konnector,
-            isConnected: konnector.accounts.length !== 0,
-            isWorking: false
+        return this.store
+          .fetchAccounts(props.params.connectorSlug, null)
+          .then(accounts => {
+            konnector.accounts = accounts
+            this.setState({
+              connector: konnector,
+              isConnected: konnector.accounts.length !== 0,
+              isWorking: false
+            })
           })
-        })
-        .catch(error => {
-          Notifier.error(t(error.message || error))
-          this.gotoParent()
-        })
       })
       .catch(error => {
         Notifier.error(t(error.message || error))

--- a/src/containers/ConnectorManagement.jsx
+++ b/src/containers/ConnectorManagement.jsx
@@ -170,7 +170,7 @@ export default class ConnectorManagement extends Component {
 
     this.setState({ submitting: true })
 
-    this.store.connectAccount(this.state.connector, account, folderPath)
+    return this.store.connectAccount(this.state.connector, account, folderPath)
       .then(connection => {
         this.setState({ submitting: false })
         if (connection.error) {
@@ -188,6 +188,8 @@ export default class ConnectorManagement extends Component {
         this.setState({ submitting: false })
         console.error(error)
         Notifier.error(t('account config error'))
+        this.gotoParent()
+        throw error
       })
   }
 

--- a/src/containers/IntentService.jsx
+++ b/src/containers/IntentService.jsx
@@ -56,9 +56,12 @@ export default class IntentService extends Component {
       })
   }
 
-  createAccount (auth) {
+  createAccount (auth, baseFolder) {
     const { konnector } = this.state
-    this.store.addAccount(konnector, auth)
+    const account = {auth: auth}
+
+    this.store.getKonnectorFolder(konnector, baseFolder)
+      .then(folder => this.store.connectAccount(konnector, account, folder))
       .then(konnector => this.terminate(konnector.accounts[konnector.accounts.length - 1]))
       .catch(error => {
         this.setState({
@@ -109,7 +112,7 @@ export default class IntentService extends Component {
             <CreateAccountService
               konnector={konnector}
               onCancel={() => this.cancel()}
-              onSubmit={auth => this.createAccount(auth)}
+              onSubmit={auth => this.createAccount(auth, t('konnector default base folder'))}
               {...this.context}
               />
           </div>}

--- a/src/containers/IntentService.jsx
+++ b/src/containers/IntentService.jsx
@@ -60,9 +60,8 @@ export default class IntentService extends Component {
     const { konnector } = this.state
     const account = {auth: auth}
 
-    this.store.getKonnectorFolder(konnector, baseFolder)
-      .then(folder => this.store.connectAccount(konnector, account, folder))
-      .then(konnector => this.terminate(konnector.accounts[konnector.accounts.length - 1]))
+    return this.store.connectAccount(konnector, account, baseFolder)
+      .then(connection => this.terminate(connection.account))
       .catch(error => {
         this.setState({
           error: {
@@ -70,6 +69,8 @@ export default class IntentService extends Component {
             reason: error.message
           }
         })
+
+        throw error
       })
   }
 

--- a/src/initKonnectors.json
+++ b/src/initKonnectors.json
@@ -9,7 +9,7 @@
     "color":{"hex":"#009DCC","css":"#009DCC"},
     "dataType":["bill"],
     "fields":{"email":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
-    "repo": "git://github.com/cozy/cozy-konnector-bouyguesbox.git"
+    "source": "git://github.com/cozy/cozy-konnector-bouyguesbox.git"
   },
   {
     "accounts":[],
@@ -21,7 +21,7 @@
     "color":{"hex":"#009DCC","css":"#009DCC"},
     "dataType":["bill"],
     "fields":{"phoneNumber":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
-    "repo": "git://github.com/cozy/cozy-konnector-bouyguestelecom.git"
+    "source": "git://github.com/cozy/cozy-konnector-bouyguestelecom.git"
   },
   {
     "accounts":[],
@@ -33,7 +33,7 @@
     "color":{"hex":"#007858","css":"#007858"},
     "fields":{"login":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
     "dataType":["bill"],
-    "repo": "git://github.com/cozy/cozy-konnector-trainline.git"
+    "source": "git://github.com/cozy/cozy-konnector-trainline.git"
   },
   {
     "accounts":[],
@@ -45,7 +45,7 @@
     "color":{"hex":"#48D5B5","css":"#48D5B5"},
     "fields":{"login":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
     "dataType":["bill"],
-    "repo": "git://github.com/cozy/cozy-konnector-trainline.git"
+    "source": "git://github.com/cozy/cozy-konnector-trainline.git"
   },
   {
     "accounts":[],
@@ -57,7 +57,7 @@
     "color":{"hex":"#9E0017","css":"linear-gradient(90deg, #EF0001 0%, #9E0017 100%)"},
     "fields":{"login":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
     "dataType":["bill"],
-    "repo": "git://github.com/cozy/cozy-konnector-sfrbox.git"
+    "source": "git://github.com/cozy/cozy-konnector-sfrbox.git"
   },
   {
     "accounts":[],
@@ -69,6 +69,6 @@
     "color":{"hex":"#9E0017","css":"linear-gradient(90deg, #EF0001 0%, #9E0017 100%)"},
     "fields":{"login":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
     "dataType":["bill"],
-    "repo": "git://github.com/cozy/cozy-konnector-sfrmobile.git"
+    "source": "git://github.com/cozy/cozy-konnector-sfrmobile.git"
   }
 ]

--- a/src/lib/DataConnectStore.js
+++ b/src/lib/DataConnectStore.js
@@ -29,9 +29,6 @@ export default class DataConnectStore {
       this.connectors = this.connectors.map(
         c => c.slug === connector.slug ? Object.assign({}, c, connector) : c
       )
-      if (this.listener) {
-        this.listener(this.find(c => c.slug === connector.slug))
-      }
     }
     return this.connectors.find(k => k.slug === connector.slug)
   }

--- a/src/lib/DataConnectStore.js
+++ b/src/lib/DataConnectStore.js
@@ -80,7 +80,7 @@ export default class DataConnectStore {
     const result = account.id
       // TODO: replace by updateAccount
       ? Promise.resolve(account)
-        : this.addAccount(konnector, account.values)
+        : this.addAccount(konnector, account.values, folder)
     result
     .then(account => {
       return cozy.client.fetchJSON('PATCH', konnector.links.permissions, {
@@ -93,7 +93,7 @@ export default class DataConnectStore {
             permissions: {
               saveFolder: {
                 type: 'io.cozy.files',
-                values: [folder._id]
+                values: [account.folderId]
               }
             }
           }
@@ -135,8 +135,8 @@ export default class DataConnectStore {
     return konnector.state && konnector.state === KONNECTOR_STATE_READY
   }
 
-  addAccount (konnector, auth) {
-    return accounts.create(cozy.client, konnector, auth)
+  addAccount (konnector, auth, folder) {
+    return accounts.create(cozy.client, konnector, auth, folder)
       .then(account => {
         const installationPromise = this.isInstalled(konnector)
           ? Promise.resolve(konnector)

--- a/src/lib/DataConnectStore.js
+++ b/src/lib/DataConnectStore.js
@@ -105,7 +105,7 @@ export default class DataConnectStore {
       // 6. Reference konnector in folder
       .then(permission => {
         connection.permission = permission
-        return cozy.client.data.addReferencedFiles(connection.konnector, connection.folder_id)
+        return cozy.client.data.addReferencedFiles(connection.konnector, connection.folder._id)
       })
       // 7. Run a job for the konnector
       .then(() => konnectors.run(

--- a/src/lib/DataConnectStore.js
+++ b/src/lib/DataConnectStore.js
@@ -86,7 +86,8 @@ export default class DataConnectStore {
       })
       // 5. Add permissions to folder for konnector
       .then(konnector => {
-        connection.konnector = this.updateConnector(konnector)
+        connection.konnector = konnector
+        this.updateConnector(konnector)
         return cozy.client.fetchJSON('PATCH', konnector.links.permissions, {
           data: {
             id: konnector.links.permissions,

--- a/src/lib/accounts.js
+++ b/src/lib/accounts.js
@@ -2,7 +2,7 @@
 
 const ACCOUNTS_DOCTYPE = 'io.cozy.accounts'
 
-export function create (cozy, konnector, auth, name = '') {
+export function create (cozy, konnector, auth, folder, name = '') {
   return cozy.data.create(ACCOUNTS_DOCTYPE, {
     name: name,
     account_type: konnector.slug,
@@ -10,7 +10,8 @@ export function create (cozy, konnector, auth, name = '') {
     auth: {
       login: auth.login,
       password: auth.password
-    }
+    },
+    folderId: folder._id
   })
 }
 

--- a/src/lib/konnectors.js
+++ b/src/lib/konnectors.js
@@ -37,17 +37,17 @@ export function install (cozy, konnector, timeout = 120000) {
     if (!konnector[property]) throw new Error(`Missing '${property}' property in konnector`)
   })
 
-  const { _id, slug, source } = konnector
+  const { slug, source } = konnector
 
-  return (_id
-    ? cozy.data.find(KONNECTORS_DOCTYPE, _id)
-      .catch(error => {
-        console.debug('install error')
-        if (error.status !== '404') throw error
-        return null
-      })
-      : Promise.resolve(null))
-    .then(konnector => konnector || cozy.fetchJSON('POST', `/konnectors/${slug}?Source=${encodeURIComponent(source)}`))
+  return findBySlug(cozy, slug)
+    .catch(error => {
+      if (error.status !== '404') throw error
+      return null
+    })
+    .then(konnector => konnector
+      // Need JSONAPI format
+      ? cozy.data.find(KONNECTORS_DOCTYPE, konnector._id)
+        : cozy.fetchJSON('POST', `/konnectors/${slug}?Source=${encodeURIComponent(source)}`))
     .then(konnector => waitForKonnectorReady(cozy, konnector, timeout))
 }
 

--- a/src/lib/konnectors.js
+++ b/src/lib/konnectors.js
@@ -32,11 +32,22 @@ export function findBySlug (cozy, slug) {
     .then(list => list.length ? list[0] : null)
 }
 
-export function install (cozy, slug, source, timeout = 120000) {
-  if (!slug) throw new Error('Missing `slug` paramater for konnector')
-  if (!source) throw new Error('Missing `source` parameter for konnector')
+export function install (cozy, konnector, timeout = 120000) {
+  ['slug', 'source'].forEach(property => {
+    if (!konnector[property]) throw new Error(`Missing '${property}' property in konnector`)
+  })
 
-  return cozy.fetchJSON('POST', `/konnectors/${slug}?Source=${encodeURIComponent(source)}`)
+  const { _id, slug, source } = konnector
+
+  return (_id
+    ? cozy.data.find(KONNECTORS_DOCTYPE, _id)
+      .catch(error => {
+        console.debug('install error')
+        if (error.status !== '404') throw error
+        return null
+      })
+      : Promise.resolve(null))
+    .then(konnector => konnector || cozy.fetchJSON('POST', `/konnectors/${slug}?Source=${encodeURIComponent(source)}`))
     .then(konnector => waitForKonnectorReady(cozy, konnector, timeout))
 }
 
@@ -65,29 +76,28 @@ function waitForKonnectorReady (cozy, konnector, timeout) {
   })
 }
 
-export function run (cozy, slug, accountId, folderId, timeout = 120 * 1000) {
-  if (!slug) throw new Error('Missing `slug` parameter for konnector')
-  if (!accountId) throw new Error('Missing `accountId` parameter for konnector')
-  if (!folderId) throw new Error('Missing `folderId` parameter for konnector')
+export function run (cozy, konnector, account, timeout = 120 * 1000) {
+  if (!konnector.attributes || !konnector.attributes.slug) {
+    throw new Error('Missing `attributes.slug` parameter for konnector')
+  }
+  if (!account._id) throw new Error('Missing `_id` parameter for account')
+  if (!account.folderId) throw new Error('Missing `folderId` parameter for account')
 
-  return findBySlug(cozy, slug)
-  .then(konnector => {
-    return cozy.fetchJSON('POST', '/jobs/queue/konnector', {
-      data: {
-        attributes: {
-          options: {
-            priority: 10,
-            timeout,
-            max_exec_count: 1
-          }
-        },
-        arguments: {
-          konnector: konnector._id,
-          account: accountId,
-          folderToSave: folderId
+  return cozy.fetchJSON('POST', '/jobs/queue/konnector', {
+    data: {
+      attributes: {
+        options: {
+          priority: 10,
+          timeout,
+          max_exec_count: 1
         }
+      },
+      arguments: {
+        konnector: konnector._id,
+        account: account._id,
+        folderToSave: account.folderId
       }
-    })
+    }
   })
   .then(job => waitForJobFinished(cozy, job, timeout))
 }

--- a/src/lib/statefulForm.jsx
+++ b/src/lib/statefulForm.jsx
@@ -111,7 +111,9 @@ export default function statefulForm (mapPropsToFormConfig) {
       }
 
       handleSubmit () {
-        if (this.props.onSubmit) this.props.onSubmit(this.getData())
+        if (this.props.onSubmit) {
+          return this.props.onSubmit(this.getData())
+        }
       }
 
       getData () {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -56,7 +56,7 @@
   "error occurred during import:": "An error occurred during the last import:",
   "import server error": "Server error occured while importing.",
   "open selected folder": "Open selected folder",
-  "konnector default base folder": "Administration/%{name}",
+  "konnector default base folder": "/Administration/%{name}",
   "konnector description darty": "Import all your Darty bills in your Cozy.",
   "konnector description malakoff_mederic": "Import your Malakoff Mederic reimbursements in your Cozy.",
   "konnector description meetup": "Synchronize your Meetup calendar with your Cozy. This konnector requires the Calendar application.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -56,7 +56,7 @@
   "error occurred during import:": "An error occurred during the last import:",
   "import server error": "Server error occured while importing.",
   "open selected folder": "Open selected folder",
-  "konnector default base folder": "Administration",
+  "konnector default base folder": "Administration/%{name}",
   "konnector description darty": "Import all your Darty bills in your Cozy.",
   "konnector description malakoff_mederic": "Import your Malakoff Mederic reimbursements in your Cozy.",
   "konnector description meetup": "Synchronize your Meetup calendar with your Cozy. This konnector requires the Calendar application.",


### PR DESCRIPTION
Ok, the first commit add the `folderId` information to an account, this is the last step of the whole account connection process. Maybe it should have been into a separate PR.

At that time, and at least in my development environment, the process fails at permission creation, as the feature is not yet implemented in the stack. At least my local one.