### PR TITLE
clean: MC-27 Removed multiple accounts

### DIFF
--- a/src/components/AccountManagement.jsx
+++ b/src/components/AccountManagement.jsx
@@ -5,27 +5,14 @@ import statefulForm from '../lib/statefulForm'
 import AccountConfigForm from './AccountConfigForm'
 
 const AccountManagement = (props) => {
-  const { t, locale, accounts, selectedAccount, lastImport, dirty, submit, cancel } = props
+  const { t, locale, selectedAccount, lastImport, dirty, submit, cancel } = props
   const { submitting, synching, deleting } = props
-  const { selectAccount, addAccount, synchronize, deleteAccount } = props
+  const { synchronize, deleteAccount } = props
   const isLoginFilled = !!props.values.login
   return (
     <div>
       <div className='account-management'>
-        <div className='account-list'>
-          <ul>
-            {accounts.map((account, key) => (
-              <li className={selectedAccount === key ? 'selected' : ''}>
-                <a onClick={() => selectAccount(key)}>
-                  {account.login
-                    ? account.login
-                    : t('account index', {index: key + 1})}
-                </a>
-              </li>
-            ))}
-          </ul>
-          <a className='add-button' onClick={() => addAccount()}>{t('add_account button')}</a>
-        </div>
+        <div className='account-list'>&nbsp;</div>
         <div className='account-config'>
           <div>
             <h3>{t('activity')}</h3>

--- a/src/containers/ConnectorManagement.jsx
+++ b/src/containers/ConnectorManagement.jsx
@@ -115,8 +115,6 @@ export default class ConnectorManagement extends Component {
               lastImport={lastImport}
               accounts={accounts}
               values={accounts[selectedAccount].auth || {}}
-              selectAccount={idx => this.selectAccount(idx)}
-              addAccount={() => this.addAccount()}
               synchronize={() => this.synchronize()}
               deleteAccount={idx => this.deleteAccount(idx)}
               cancel={() => this.gotoParent()}
@@ -142,20 +140,6 @@ export default class ConnectorManagement extends Component {
 
   selectAccount (idx) {
     this.setState({ selectedAccount: idx })
-  }
-
-  addAccount () {
-    const { t } = this.context
-    this.store.addAccount(this.state.connector, this.getDefaultValues())
-    .then(connector => {
-      this.setState({
-        connector
-      })
-      this.selectAccount(this.state.connector.accounts.length - 1)
-    })
-    .catch(() => {
-      Notifier.error(t('account config error'))
-    })
   }
 
   async connectAccount ({login, password, folderPath}) {

--- a/src/styles/dialog.styl
+++ b/src/styles/dialog.styl
@@ -54,20 +54,6 @@
 
 .account-list
     width 25%
-    ul
-        margin 2.4em 1em .5em 0
-    li
-        padding       .5em 1em
-        color         grey-08
-        font-weight   bold
-        text-overflow ellipsis
-        white-space   nowrap
-        overflow      hidden
-        &.selected
-            background-color grey-10
-            a
-                color grey-08
-
 .account-config
     .account-field
         max-width 80%


### PR DESCRIPTION
This removes the account list and account creation button in the connector management dialog. I also removed unused styles.

This commit will be tagged so that we can add multiple accounts back when needed.