### PR TITLE
fix(accounts): allow fields other than login/password

### DIFF
--- a/src/lib/accounts.js
+++ b/src/lib/accounts.js
@@ -7,10 +7,7 @@ export function create (cozy, konnector, auth, folder, name = '') {
     name: name,
     account_type: konnector.slug,
     status: 'PENDING',
-    auth: {
-      login: auth.login,
-      password: auth.password
-    },
+    auth: auth,
     folderId: folder._id
   })
 }


### PR DESCRIPTION
In my connector, `email` is used.

fixes https://github.com/cozy/cozy-data-connect/issues/54 